### PR TITLE
Fixed bug on destroy. Now it tracks save's pattern

### DIFF
--- a/src/orm/model.js
+++ b/src/orm/model.js
@@ -50,9 +50,8 @@ class Model {
 
   destroy(obj) {
     const qb = new QueryBuilder();
-    obj.table = this.tableName;
     return qb
-      .destroy(obj)
+      .destroy({ table: this.tableName, where: obj })
       .fire();
   }
 


### PR DESCRIPTION
### Summary

<!--- Provide a general summary of your changes in the Title above -->

Now destroy track's Model.save()'s pattern
##### Description

<!--- Describe your changes in detail -->

Destroy now matches the columns first before destroying. No longer need to put where tag.
##### Related Issue

<!--- This project only accepts pull requests related to open issues -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here: -->
##### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
##### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Automated Testing
- [ ] Documentation
##### Testing Details

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

<!--- If there are none to be shared, report 'Travis CI - Build Passing'  -->
##### Screenshots (if appropriate)

<!--- Report 'N/A' if none --->
### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] I have made any needed updates to the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
